### PR TITLE
feat: upgrade to node 14 for compiler settings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/dist/index.js
+++ b/dist/index.js
@@ -5579,6 +5579,7 @@ exports.getInput = getInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
+    process.stdout.write(os.EOL);
     command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Github Action for verifying if a Git tag exists in a target repository",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10.15.0"
+    "node": ">=14"
   },
   "scripts": {
     "prepare": "husky install",
@@ -36,17 +36,18 @@
     "@actions/exec": "1.0.4",
     "@commitlint/cli": "12.1.1",
     "@side/commitlint-config": "0.1.4",
-    "@side/eslint-config-base": "0.11.2",
-    "@side/eslint-config-jest": "0.2.1",
+    "@side/eslint-config-base": "0.11.3",
+    "@side/eslint-config-jest": "0.3.8",
+    "@tsconfig/node14": "1.0.0",
     "@types/fs-extra": "9.0.11",
     "@types/jest": "26.0.22",
-    "@types/js-yaml": "4.0.0",
+    "@types/js-yaml": "4.0.1",
     "@types/node": "14.14.41",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
     "@zeit/ncc": "0.22.3",
     "eslint": "7.24.0",
-    "eslint-plugin-jsdoc": "32.3.0",
+    "eslint-plugin-jsdoc": "32.3.1",
     "husky": "6.0.0",
     "jest": "26.6.3",
     "js-yaml": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,27 +773,27 @@
   dependencies:
     "@commitlint/config-conventional" "^12.0.1"
 
-"@side/eslint-config-base@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@side/eslint-config-base/-/eslint-config-base-0.11.2.tgz#c8f585dce6596c8e3a4dd229207b82f701de2e24"
-  integrity sha512-cmg/69Xv3mXgkNn5TPE+y5gq1qwhe4Qrrx/UoH9v6sXu0tffHivhlRA+j97tpJig49OnSDNKdR3GoFOfn7n/sA==
+"@side/eslint-config-base@0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@side/eslint-config-base/-/eslint-config-base-0.11.3.tgz#b1d113472c68a2f9a3ab7fe51c31fd75b0e077d9"
+  integrity sha512-p/ITn/plumZlgSwBw3SdyAlDYYuTOPRiihb96T19oP/c7d+25ZLOd/dCNQ2svD3BDGKTMjtwRwO3QpNUQbisTw==
   dependencies:
-    "@side/eslint-config-prettier" "0.4.3"
+    "@side/eslint-config-prettier" "0.4.4"
     eslint-config-airbnb-base "^14.1.0"
     eslint-plugin-import "^2.20.2"
     glob "7.1.6"
 
-"@side/eslint-config-jest@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@side/eslint-config-jest/-/eslint-config-jest-0.2.1.tgz#c4834cbd7e5f34123ac4139b10f27a79fdb402ff"
-  integrity sha512-oNTTorZBnxmEV/BWOvSeg7wKIOf6z3lUbjdt3/xasbdIRwFmTqtGmu0ZUiIn+heW0Y76rypJxxt6TWzbbl+rAA==
+"@side/eslint-config-jest@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@side/eslint-config-jest/-/eslint-config-jest-0.3.8.tgz#8605b5a70a360c6e8a8fefba258752fe3f54454c"
+  integrity sha512-c2aHzfxHGIcbCiGYBxeIJ0E3RPSaZx7NlXbi5Wt5++3HrG8N/lBD23bfeFeEr9rhpI2RLmC+R99P8HunWdJKIg==
   dependencies:
-    eslint-plugin-jest "23.13.2"
+    eslint-plugin-jest "24.3.5"
 
-"@side/eslint-config-prettier@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@side/eslint-config-prettier/-/eslint-config-prettier-0.4.3.tgz#3fc23bfb15894a9bc9b9d50b6cac9d2465b72657"
-  integrity sha512-9wGRtufRVa54FfmIi5KAbxQtK//0zxN1tEsjz+cqOWdYI3EfetE32UNmfDsqVM1Eck5lJHWuRQQYM1FKAUEhlw==
+"@side/eslint-config-prettier@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@side/eslint-config-prettier/-/eslint-config-prettier-0.4.4.tgz#294b529ed8571c255b600270bea583331f6c613b"
+  integrity sha512-Lwzduu9uMw+CLL2psnuMvwoVBphNH7O6C9ZEGQ+BJnnKzA/3kPAr8hpXENr3tSgoqC87+1haZ5dtXB4NIE4zAw==
   dependencies:
     eslint-config-prettier "^8.1.0"
     eslint-plugin-prettier "^3.1.3"
@@ -811,6 +811,11 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@tsconfig/node14@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.0.tgz#5bd046e508b1ee90bc091766758838741fdefd6e"
+  integrity sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -898,10 +903,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/js-yaml@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.0.tgz#d1a11688112091f2c711674df3a65ea2f47b5dfb"
-  integrity sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==
+"@types/js-yaml@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.1.tgz#5544730b65a480b18ace6b6ce914e519cec2d43b"
+  integrity sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==
 
 "@types/json-schema@^7.0.3":
   version "7.0.5"
@@ -969,7 +974,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.22.0":
+"@typescript-eslint/experimental-utils@4.22.0", "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
   integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
@@ -978,16 +983,6 @@
     "@typescript-eslint/scope-manager" "4.22.0"
     "@typescript-eslint/types" "4.22.0"
     "@typescript-eslint/typescript-estree" "4.22.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/experimental-utils@^2.5.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -1013,19 +1008,6 @@
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
   integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.22.0":
   version "4.22.0"
@@ -2077,17 +2059,17 @@ eslint-plugin-import@^2.20.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jest@23.13.2:
-  version "23.13.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.13.2.tgz#7b7993b4e09be708c696b02555083ddefd7e4cc7"
-  integrity sha512-qZit+moTXTyZFNDqSIR88/L3rdBlTU7CuW6XmyErD2FfHEkdoLgThkRbiQjzgYnX6rfgLx3Ci4eJmF4Ui5v1Cw==
+eslint-plugin-jest@24.3.5:
+  version "24.3.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.5.tgz#71f0b580f87915695c286c3f0eb88cf23664d044"
+  integrity sha512-XG4rtxYDuJykuqhsOqokYIR84/C8pRihRtEpVskYLbIIKGwPNW2ySxdctuVzETZE+MbF/e7wmsnbNVpzM0rDug==
   dependencies:
-    "@typescript-eslint/experimental-utils" "^2.5.0"
+    "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-jsdoc@32.3.0:
-  version "32.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz#7c9fa5da8c72bd6ad7d97bbf8dee8bc29bec3f9e"
-  integrity sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==
+eslint-plugin-jsdoc@32.3.1:
+  version "32.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.1.tgz#1c50b82b12f903bdb4117f7b68e97fb2f65a5f73"
+  integrity sha512-Xcbc8Cr79QveH+MndVwtZ3uafDdXyrsIkS8lP71Fhn5Qi1Lr8TU2QZNkMYIJSvmuLqDB5Jj/VVULMCvaBZBkvg==
   dependencies:
     comment-parser "1.1.2"
     debug "^4.3.1"
@@ -2574,7 +2556,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
- chore(dev-deps): upgrade @side/eslint-config-base from 0.11.2 to 0.11.3
- chore(dev-deps): upgrade @side/eslint-config-jest from 0.2.1 to 0.3.8
- chore(dev-deps): upgrade @types/js-yaml from 4.0.0 to 4.0.1
- chore(dev-deps): upgrade eslint-plugin-jsdoc from 32.3.0 to 32.3.1
- chore(dev-deps): add @tsconfig/node14@1.0.0

BREAKING CHANGE: Drop support for Node 10 and Node 12