### PR TITLE
ci: implement ci status notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}
+
+  notification:
+    if: always()
+    name: notification
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}

--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -48,3 +48,20 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  notification:
+    if: always() && github.actor == 'dependabot[bot]'
+    name: notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: technote-space/workflow-conclusion-action@v2.0.1
       
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+      - uses: reside-eng/workflow-status-notification-action@v1.0.0
         with:
           current-status: ${{ env.WORKFLOW_CONCLUSION }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,3 +43,20 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  notification:
+    if: always() && github.actor != 'dependabot[bot]'
+    name: notification
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+
+      - uses: technote-space/workflow-conclusion-action@v2.0.1
+      
+      - uses: reside-eng/workflow-status-slack-notification@v1.0.0
+        with:
+          current-status: ${{ env.WORKFLOW_CONCLUSION }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK_PLATFORM_PROD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use of our new Github custom action for CI success/failure slack notifications (workflow-status-slack-notification).
For each branch/PR we'll be notified if:
- A workflow is failing for the first time (failure notification)
- A workflow is failing and previous attempt was successful (failure notification)
- A workflow is succeeding and previous attempt was failed (success notification)
We'll not be notified if:
- A workflow is succeeding and previous attempt was successful (or it is the first run)
- A workflow is failing and previous attempt was failed (notification already sent on the first failed attempt)

This works for new commits triggering a workflow but also when re-running the same workflow thanks to the github workflow cache feature.

We specify the slack channel we want to send the notification to with a webhook specified as a secret.
This webhook is specific to a channel and can be created/retrieved here: https://api.slack.com/apps/A02N76U245V/incoming-webhooks?

We could create a specific channel/webhook for each repository.
We could use an existing channel/webhook for each repository.
We could have a general/common channel/webhook for CI status for all repositories.

For this repo we're going to use:
- `SLACK_WEBHOOK_PLATFORM_PROD` for all our workflows
note: currently all platform alerts (all environments) are going to eng-platform-alerts, if at some point we want to have different channels for prod/non-prod related workflows alerts, we could do as for core and have two different channels/webhooks.

Currently we can only specify one channel/webhook but if we have the need to send notifications to multiple channel/webhook, it would be easy to add this capability to our custom action, so don't hesitate.

Don't hesitate if you have any comment/question.