### PR TITLE
Revert "chore(deps-dev): bump @types/node from 16.11.13 to 17.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/jest": "27.0.3",
     "@types/js-yaml": "4.0.5",
-    "@types/node": "17.0.0",
+    "@types/node": "16.11.13",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "@vercel/ncc": "0.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,10 +1230,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@17.0.0", "@types/node@>= 8":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
-  integrity sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==
+"@types/node@*", "@types/node@16.11.13", "@types/node@>= 8":
+  version "16.11.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.13.tgz#6b71641b81a98c6a538d89892440c06f147edddc"
+  integrity sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Reverts reside-eng/verify-git-tag-action#347<

https://github.com/reside-eng/verify-git-tag-action/pull/347#issuecomment-996937480